### PR TITLE
Expose Archive.read() options and increase default read chunk size

### DIFF
--- a/src/archive/archive-reader.ts
+++ b/src/archive/archive-reader.ts
@@ -1,5 +1,5 @@
 import type { ArchiveContext } from '../common/archive-context.ts';
-import { AsyncUint8ArrayIterator, AsyncUint8ArrayIteratorInput } from '../common/async-uint8-array-iterator.ts';
+import { AsyncUint8ArrayIterator, AsyncUint8ArrayIteratorInput, AsyncUint8ArrayIteratorOptions } from '../common/async-uint8-array-iterator.ts';
 import { AsyncUint8ArrayLike, InMemoryAsyncUint8Array } from '../common/async-uint8-array.ts';
 import { Constants } from '../common/constants.ts';
 import { TarUtility } from '../common/tar-utility.ts';
@@ -16,6 +16,8 @@ interface TarHeaderParseResult {
 	headerOffset: number;
 	contentOffset: number;
 }
+
+export type ArchiveReaderInputOptions = Partial<AsyncUint8ArrayIteratorOptions>;
 
 /**
  * Errors that will be thrown if the reader encounters an invalid data layout
@@ -51,8 +53,8 @@ export class ArchiveReader implements ArchiveContext, AsyncIterableIterator<Arch
 		this.mHasSyncInput = this.bufferIterator.input instanceof InMemoryAsyncUint8Array;
 	}
 
-	public static withInput(input: AsyncUint8ArrayIteratorInput): ArchiveReader {
-		return new ArchiveReader(new AsyncUint8ArrayIterator(input));
+	public static withInput(input: AsyncUint8ArrayIteratorInput, options?: ArchiveReaderInputOptions): ArchiveReader {
+		return new ArchiveReader(new AsyncUint8ArrayIterator(input, options));
 	}
 
 	[Symbol.asyncIterator](): AsyncIterableIterator<ArchiveEntry> {

--- a/src/archive/archive.ts
+++ b/src/archive/archive.ts
@@ -1,6 +1,6 @@
 import { AsyncUint8ArrayIteratorInput } from '../common/async-uint8-array-iterator.ts';
 import { ArchiveEntry } from './archive-entry.ts';
-import { ArchiveReader } from './archive-reader.ts';
+import { ArchiveReader, ArchiveReaderInputOptions } from './archive-reader.ts';
 import { ArchiveWriter } from './archive-writer.ts';
 
 /**
@@ -26,7 +26,7 @@ export class Archive extends ArchiveWriter {
 	 * Iterate over entries in-place from a given source buffer.
 	 * The buffer should come from a complete, uncompressed tar file.
 	 */
-	public static read(input: AsyncUint8ArrayIteratorInput): AsyncIterable<ArchiveEntry> {
-		return ArchiveReader.withInput(input);
+	public static read(input: AsyncUint8ArrayIteratorInput, options?: ArchiveReaderInputOptions): AsyncIterable<ArchiveEntry> {
+		return ArchiveReader.withInput(input, options);
 	}
 }

--- a/src/common/async-uint8-array-iterator.ts
+++ b/src/common/async-uint8-array-iterator.ts
@@ -40,17 +40,17 @@ export interface AsyncUint8ArrayIteratorOptions {
 	blockSize: number;
 }
 
+const MIN_BLOCK_SIZE = Constants.SECTOR_SIZE;
+const MAX_BLOCK_SIZE = Constants.SECTOR_SIZE * 10000 * 4; // ~20MB
+
 function sanitizeOptions(options: Partial<AsyncUint8ArrayIteratorOptions>): AsyncUint8ArrayIteratorOptions {
 	return Object.assign(
 		{
-			blockSize: Constants.SECTOR_SIZE * 16, // 8Kb
+			blockSize: MAX_BLOCK_SIZE / 2,
 		},
 		options,
 	);
 }
-
-const MIN_BLOCK_SIZE = Constants.SECTOR_SIZE;
-const MAX_BLOCK_SIZE = Constants.SECTOR_SIZE * 10000;
 
 /**
  * Generalized abstraction for pulling in raw octet data, whether its

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { ArchiveEntry, ArchiveEntryOptions } from './archive/archive-entry.ts';
-export { ArchiveReader, ArchiveReadError } from './archive/archive-reader.ts';
+export { ArchiveReader, ArchiveReaderInputOptions, ArchiveReadError } from './archive/archive-reader.ts';
 export { ArchiveEntryPredicate, ArchiveWriter } from './archive/archive-writer.ts';
 export { Archive } from './archive/archive.ts';
 export { ArchiveContext } from './common/archive-context.ts';
@@ -8,7 +8,7 @@ export {
 	AsyncUint8ArrayIterator,
 	AsyncUint8ArrayIteratorInput,
 	AsyncUint8ArrayIteratorLike,
-	AsyncUint8ArrayIteratorOptions,
+	AsyncUint8ArrayIteratorOptions
 } from './common/async-uint8-array-iterator.ts';
 export { AsyncUint8ArrayLike, InMemoryAsyncUint8Array } from './common/async-uint8-array.ts';
 export { Constants } from './common/constants.ts';
@@ -20,10 +20,11 @@ export { TarHeaderUtility } from './header/tar-header-utility.ts';
 export { TarHeader, TarHeaderOptions } from './header/tar-header.ts';
 export {
 	UstarHeaderFieldTransform,
-	UstarHeaderFieldTransformType,
+	UstarHeaderFieldTransformType
 } from './header/ustar/ustar-header-field-transform.ts';
 export { UstarHeaderFieldType } from './header/ustar/ustar-header-field-type.ts';
 export { UstarHeaderField, UstarHeaderFieldLike } from './header/ustar/ustar-header-field.ts';
 export { UstarHeaderLike } from './header/ustar/ustar-header-like.ts';
 export { UstarHeaderLinkIndicatorType } from './header/ustar/ustar-header-link-indicator-type.ts';
 export { UstarHeader } from './header/ustar/ustar-header.ts';
+


### PR DESCRIPTION
expose AsyncUint8ArrayIteratorOptions through Archive.read() utility, increase default async block size from 8kb to 10mb

Fixes #11 